### PR TITLE
Add rpc.allow-unprotected-txs to support non-EIP-155 transactions.

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -69,6 +69,7 @@ type Flags struct {
 	GRPCListenAddress      string
 	GRPCPort               int
 	GRPCHealthCheckEnabled bool
+	AllowUnprotectedTxs    bool
 }
 
 var rootCmd = &cobra.Command{
@@ -107,6 +108,7 @@ func RootCommand() (*cobra.Command, *Flags) {
 	rootCmd.PersistentFlags().StringVar(&cfg.GRPCListenAddress, "grpc.addr", node.DefaultGRPCHost, "GRPC server listening interface")
 	rootCmd.PersistentFlags().IntVar(&cfg.GRPCPort, "grpc.port", node.DefaultGRPCPort, "GRPC server listening port")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GRPCHealthCheckEnabled, "grpc.healthcheck", false, "Enable GRPC health check")
+	rootCmd.PersistentFlags().BoolVar(&cfg.AllowUnprotectedTxs, "rpc.allow-unprotected-txs", false, "Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC")
 
 	if err := rootCmd.MarkPersistentFlagFilename("rpc.accessList", "json"); err != nil {
 		panic(err)

--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -25,7 +25,7 @@ func APIList(ctx context.Context, db kv.RoDB,
 	if cfg.TevmEnabled {
 		base.EnableTevmExperiment()
 	}
-	ethImpl := NewEthAPI(base, db, eth, txPool, mining, cfg.Gascap)
+	ethImpl := NewEthAPI(base, db, eth, txPool, mining, cfg.Gascap, SetAllowUnprotectedTxs(cfg.AllowUnprotectedTxs))
 	erigonImpl := NewErigonAPI(base, db, eth)
 	starknetImpl := NewStarknetAPI(base, db, txPool)
 	txpoolImpl := NewTxPoolAPI(base, db, txPool)

--- a/cmd/rpcdaemon/commands/eth_api_option.go
+++ b/cmd/rpcdaemon/commands/eth_api_option.go
@@ -1,0 +1,21 @@
+package commands
+
+// EthAPIOption is an option that can be set with NewEthAPI
+type EthAPIOption interface {
+	Apply(*APIImpl)
+}
+
+// EthAPIOptionFunc is a function defined for *APIImpl
+type EthAPIOptionFunc func(*APIImpl)
+
+// Apply is a wrapper function used to call the actual function
+func (f EthAPIOptionFunc) Apply(sd *APIImpl) {
+	f(sd)
+}
+
+// SetAllowUnprotectedTxs is an option that can set allowUnprotectedTxs for *APIImpl
+func SetAllowUnprotectedTxs(allowUnprotectedTxs bool) EthAPIOption {
+	return EthAPIOptionFunc(func(p *APIImpl) {
+		p.allowUnprotectedTxs = allowUnprotectedTxs
+	})
+}

--- a/cmd/rpcdaemon/commands/send_transaction.go
+++ b/cmd/rpcdaemon/commands/send_transaction.go
@@ -31,7 +31,7 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 	if err := checkTxFee(txn.GetPrice().ToBig(), txn.GetGas(), ethconfig.Defaults.RPCTxFeeCap); err != nil {
 		return common.Hash{}, err
 	}
-	if !txn.Protected() {
+	if !api.allowUnprotectedTxs && !txn.Protected() {
 		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
 	}
 	hash := txn.Hash()


### PR DESCRIPTION
This PR provides users to submit non-EIP-155 transactions with rpc endpoint.
This behavior can be overridden by specifying the flag `--rpc.allow-unprotected-txs=true`.