### PR TITLE
Fix the branch list set by ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,14 @@ name: Continuous integration
 on:
   push:
     branches:
-      - devel
-      - stable
+      - bsc
+      - develop
+      - main
   pull_request:
     branches:
-      - devel
-      - stable
+      - bsc
+      - develop
+      - main
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
The ci will check:
 - `build`
 - `lint`
 - `unit test`
 - `docker build`

This pr modifies the list of branches triggered by ci.